### PR TITLE
End of line error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const InvalidOperationError = require('./InvalidOperationError')
 const OperationNotSupportedError = require('./OperationNotSupportedError')
 const types = require('./types')
 const asn = require('./asn1')
-const EOL = require('os').EOL;
+const EOL = RegExp('\r?\n', 'g');
 
 /**
  * JWK


### PR DESCRIPTION
On windows pem generated by openssl have a \n instead of the os EOL and it crashes the test when i try.
I replaced it with a regex which should allow both windows and linux system to split on end of line. Without this change the test were breaking on my machine